### PR TITLE
Remove note on not supporting streaming put from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ This is a Ruby (with Rust backend) client for the [CipherStash encrypted, search
 > While we're happy for you to use it, and most things work, there are a couple of things missing.
 > If something *not* on the list below is broken for you, please [report an issue](https://github.com/cipherstash/ruby-client/issues).
 >
-> At present, the following things are known to not be supported:
->
-> * Streaming put
-> * Interacting with collections or records created with StashJS
+> At present, interacting with collections or records created with StashJS is not supported.
 
 
 # Installation


### PR DESCRIPTION
Streaming put has be implemented and is now supported.

See: https://github.com/cipherstash/ruby-client/commit/1f0a1cd0c81eee15db3ef2b3da826491d3704a17.