### PR TITLE
Add ability to specify unique constraint on exact and range indexes

### DIFF
--- a/cipherstash-client.gemspec
+++ b/cipherstash-client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "aws-sdk-core", "~> 3.0"
   s.add_runtime_dependency "aws-sdk-kms", "~> 1.0"
   s.add_runtime_dependency 'cbor', '~> 0.5.9.6'
-  s.add_runtime_dependency "cipherstash-grpc", "= 0.20220706.5"
+  s.add_runtime_dependency "cipherstash-grpc", "= 0.20220801.1"
   s.add_runtime_dependency "enveloperb", "~> 0.0"
   s.add_runtime_dependency "launchy", "~> 2.5"
   s.add_runtime_dependency "ore-rs", "~> 0.0"

--- a/lib/cipherstash/client.rb
+++ b/lib/cipherstash/client.rb
@@ -155,10 +155,6 @@ module CipherStash
         }
 
         indexes = schema.fetch("indexes", {}).map do |idx_name, idx_settings|
-          if Index.invalid_unique_constraint?(idx_settings["unique"], idx_settings["kind"])
-            raise CipherStash::Client::Error::InvalidSchemaError, "Unique constraint not allowed on type #{idx_settings["kind"].inspect}" 
-          end
-
           # New match, dynamic-match, and field-dynamic-match indexes should use filter indexes.
           # ORE match indexes require specifically using a *-ore-match index.
           idx_settings["kind"] = case idx_settings["kind"]

--- a/lib/cipherstash/client.rb
+++ b/lib/cipherstash/client.rb
@@ -145,6 +145,8 @@ module CipherStash
     #
     # @raise [CipherStash::Client::Error::DecryptionFailure] if there was a problem decrypting the naming key.
     #
+    # @raise [CipherStash::Client::Error::InvalidSchemaError] if there was a problem with the format of the schema.
+    #
     def create_collection(name, schema)
       @metrics.measure_client_call("create_collection") do
         metadata = {
@@ -153,6 +155,10 @@ module CipherStash
         }
 
         indexes = schema.fetch("indexes", {}).map do |idx_name, idx_settings|
+          if Index.invalid_unique_constraint?(idx_settings["unique"], idx_settings["kind"])
+            raise CipherStash::Client::Error::InvalidSchemaError, "Unique constraint not allowed on type #{idx_settings["kind"].inspect}" 
+          end
+
           # New match, dynamic-match, and field-dynamic-match indexes should use filter indexes.
           # ORE match indexes require specifically using a *-ore-match index.
           idx_settings["kind"] = case idx_settings["kind"]

--- a/lib/cipherstash/client/rpc.rb
+++ b/lib/cipherstash/client/rpc.rb
@@ -79,6 +79,7 @@ module CipherStash
                     id: blob_from_uuid(idx[:meta]["$indexId"]),
                     settings: encrypt_blob(idx.to_cbor, "createCollection"),
                     type: index_type(idx[:mapping]["kind"]),
+                    unique: idx[:mapping]["unique"]
                   }
                 end
               )
@@ -103,6 +104,7 @@ module CipherStash
                     id: blob_from_uuid(idx[:meta]["$indexId"]),
                     settings: encrypt_blob(idx.to_cbor, "migrateCollection"),
                     type: index_type(idx[:mapping]["kind"]),
+                    unique: idx[:mapping]["unique"]
                   }
                 end,
                 fromSchemaVersion: from_schema_version
@@ -158,6 +160,8 @@ module CipherStash
         uuid_from_blob(id)
       rescue ::GRPC::NotFound
         raise Error::RecordPutFailure, "Collection '#{collection.name}' not found"
+      rescue ::GRPC::InvalidArgument => ex
+        raise Error::RecordPutFailure, "Error while putting record into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       rescue ::GRPC::BadStatus => ex
         raise Error::RecordPutFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       end
@@ -279,6 +283,10 @@ module CipherStash
         res.numInserted
       rescue ::GRPC::NotFound
         raise Error::RecordDeleteFailure, "Collection '#{collection.name}' not found"
+      rescue ::GRPC::InvalidArgument => ex
+        raise Error::RecordPutFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
+      rescue ::GRPC::BadStatus => ex
+        raise Error::RecordGetFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       end
 
       def delete(collection, id)

--- a/lib/cipherstash/client/rpc.rb
+++ b/lib/cipherstash/client/rpc.rb
@@ -282,11 +282,11 @@ module CipherStash
 
         res.numInserted
       rescue ::GRPC::NotFound
-        raise Error::RecordDeleteFailure, "Collection '#{collection.name}' not found"
+        raise Error::RecordPutFailure, "Collection '#{collection.name}' not found"
       rescue ::GRPC::InvalidArgument => ex
         raise Error::RecordPutFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       rescue ::GRPC::BadStatus => ex
-        raise Error::RecordGetFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
+        raise Error::RecordPutFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       end
 
       def delete(collection, id)

--- a/lib/cipherstash/index.rb
+++ b/lib/cipherstash/index.rb
@@ -35,6 +35,19 @@ module CipherStash
         end
       end
 
+      def invalid_unique_constraint?(unique, kind)
+        [
+          "match",
+          "ore-match",
+          "filter-match",
+          "field-dynamic-match",
+          "field-dynamic-filter-match",
+          "field-dynamic-ore-match",
+          "dynamic-match",
+          "dynamic-filter-match",
+          "dynamic-ore-match"].include?(kind) && unique
+      end
+
       def generate(id, settings, schema_versions)
         subclass = subclass_from_kind(settings["mapping"]["kind"])
         subclass.new(id, settings, schema_versions)

--- a/lib/cipherstash/index/dynamic_filter_match.rb
+++ b/lib/cipherstash/index/dynamic_filter_match.rb
@@ -26,6 +26,10 @@ module CipherStash
         def orderable?
           false
         end
+        
+        def self.uniqueness_supported?
+          false
+        end
 
         def analyze(uuid, record)
           blid = blob_from_uuid(uuid)

--- a/lib/cipherstash/index/dynamic_ore_match.rb
+++ b/lib/cipherstash/index/dynamic_ore_match.rb
@@ -22,6 +22,10 @@ module CipherStash
         false
       end
 
+      def self.uniqueness_supported?
+        false
+      end
+
       def analyze(uuid, record)
         blid = blob_from_uuid(uuid)
         raw_terms = collect_string_fields(record).map(&:last)

--- a/lib/cipherstash/index/exact.rb
+++ b/lib/cipherstash/index/exact.rb
@@ -26,6 +26,10 @@ module CipherStash
         false
       end
 
+      def self.uniqueness_supported?
+        true
+      end
+
       def analyze(uuid, record)
         blid = blob_from_uuid(uuid)
 

--- a/lib/cipherstash/index/field_dynamic_exact.rb
+++ b/lib/cipherstash/index/field_dynamic_exact.rb
@@ -18,6 +18,10 @@ module CipherStash
         self.ore_meta(name)
       end
 
+      def self.uniqueness_supported?
+        false
+      end
+
       def analyze(uuid, record)
         blid = blob_from_uuid(uuid)
 

--- a/lib/cipherstash/index/field_dynamic_filter_match.rb
+++ b/lib/cipherstash/index/field_dynamic_filter_match.rb
@@ -23,6 +23,10 @@ module CipherStash
           self.filter_meta(name)
         end
 
+        def self.uniqueness_supported?
+          false
+        end
+
         def analyze(uuid, record)
           blid = blob_from_uuid(uuid)
 

--- a/lib/cipherstash/index/field_dynamic_ore_match.rb
+++ b/lib/cipherstash/index/field_dynamic_ore_match.rb
@@ -18,6 +18,10 @@ module CipherStash
         self.ore_meta(name)
       end
 
+      def self.uniqueness_supported?
+        false
+      end
+
       def analyze(uuid, record)
         blid = blob_from_uuid(uuid)
 

--- a/lib/cipherstash/index/filter_match.rb
+++ b/lib/cipherstash/index/filter_match.rb
@@ -27,6 +27,10 @@ module CipherStash
           false
         end
 
+        def self.uniqueness_supported?
+          false
+        end
+
         def analyze(uuid, record)
           blid = blob_from_uuid(uuid)
 

--- a/lib/cipherstash/index/ore_match.rb
+++ b/lib/cipherstash/index/ore_match.rb
@@ -22,6 +22,10 @@ module CipherStash
         false
       end
 
+      def self.uniqueness_supported?
+        false
+      end
+
       def analyze(uuid, record)
         blid = blob_from_uuid(uuid)
 

--- a/lib/cipherstash/index/range.rb
+++ b/lib/cipherstash/index/range.rb
@@ -47,6 +47,10 @@ module CipherStash
         true
       end
 
+      def self.uniqueness_supported?
+        true
+      end
+
       def analyze(uuid, record)
         blid = blob_from_uuid(uuid)
 

--- a/spec/cipherstash/client_spec.rb
+++ b/spec/cipherstash/client_spec.rb
@@ -167,5 +167,70 @@ describe CipherStash::Client do
         end
       end
     end
+
+    ["exact", "range"].each do |input_kind|
+      context "given a schema with a #{input_kind} index" do
+        def schema(kind)
+          mapping = {
+            "kind" => kind,
+            "field" => "title",
+            "unique" => true
+          }
+
+          {
+            "type" => {"title" => "string"},
+            "indexes" => {
+              "exactTitle" => mapping,
+            },
+          }
+        end
+
+        it "can specify field as unique" do
+          schema = schema(input_kind)
+
+          expect(rpc).to receive(:create_collection).with(
+            anything,
+            anything,
+            array_including(hash_including(mapping: hash_including("unique" => true)))
+          )
+
+          client.create_collection("name", schema)
+        end
+      end
+    end
+
+    [
+      "match",
+      "ore-match",
+      "filter-match",
+      "field-dynamic-match",
+      "field-dynamic-filter-match",
+      "field-dynamic-ore-match",
+      "dynamic-match",
+      "dynamic-filter-match",
+      "dynamic-ore-match"].each do |input_kind|
+      context "given a schema with a #{input_kind} index" do
+        def schema(kind)
+          mapping = {
+            "kind" => kind,
+            "field" => "title",
+            "unique" => true
+          }
+
+          {
+            "type" => {"title" => "string"},
+            "indexes" => {
+              "title" => mapping,
+            },
+          }
+        end
+
+        it "can not specify field as unique" do
+          schema = schema(input_kind)
+
+          expect { client.create_collection("name", schema) }.to raise_error(CipherStash::Client::Error::InvalidSchemaError)
+        end
+      end
+    end
   end
-end
+end 


### PR DESCRIPTION
Updates the ruby client to allow a range or exact index to specify a unique constraint.

This can be tested in conjunction with this E2E test PR in platform

https://github.com/cipherstash/platform/pull/1139

Pull the E2E PR down and this branch.
Run bundle install in this branch
In `cipherstash/platform/e2e/ruby` run `RUBYLIB=/users/<yourname>/cipherstash/ruby-client/lib ./run.sh dev-local 0`, substituting your username in the file path.