### PR TITLE
Update error returned to a RecordPutError

### DIFF
--- a/lib/cipherstash/client/error.rb
+++ b/lib/cipherstash/client/error.rb
@@ -67,6 +67,9 @@ module CipherStash
       # An error occured while migration records.
       class RecordMigrateFailure < Error; end
 
+      # A client error occured while storing a record.
+      class RecordPutError < Error; end
+
       # A query constraint was specified incorrectly.
       #
       # Either a non-existent index was referenced, or an operator was specified that is not supported on the given index.

--- a/lib/cipherstash/client/rpc.rb
+++ b/lib/cipherstash/client/rpc.rb
@@ -161,7 +161,7 @@ module CipherStash
       rescue ::GRPC::NotFound
         raise Error::RecordPutFailure, "Collection '#{collection.name}' not found"
       rescue ::GRPC::InvalidArgument => ex
-        raise Error::RecordPutFailure, "Error while putting record into collection '#{collection.name}': #{ex.message} (#{ex.class})"
+        raise Error::RecordPutError, "Error while putting record into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       rescue ::GRPC::BadStatus => ex
         raise Error::RecordPutFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       end
@@ -284,7 +284,7 @@ module CipherStash
       rescue ::GRPC::NotFound
         raise Error::RecordPutFailure, "Collection '#{collection.name}' not found"
       rescue ::GRPC::InvalidArgument => ex
-        raise Error::RecordPutFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
+        raise Error::RecordPutError, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       rescue ::GRPC::BadStatus => ex
         raise Error::RecordPutFailure, "Error while putting records into collection '#{collection.name}': #{ex.message} (#{ex.class})"
       end


### PR DESCRIPTION
Updates the error raised on a unique constraint violation to be an error instead of a failure.

Related to addressing this comment on the docs PR https://github.com/cipherstash/platform/pull/1144#discussion_r943010626