### PR TITLE
catch launchy exception

### DIFF
--- a/lib/cipherstash/client/auth0_device_code_credentials.rb
+++ b/lib/cipherstash/client/auth0_device_code_credentials.rb
@@ -148,7 +148,12 @@ module CipherStash
       def prompt_user(polling_info)
         code = polling_info[:user_code]
 
-        Launchy.open polling_info[:verification_uri_complete]
+        begin
+          Launchy.open polling_info[:verification_uri_complete]
+        rescue Launchy::CommandNotFoundError
+          # We could be running in a headless environment, in which case, the user should just open the url in a browser on a separate machine
+          @logger.debug("Auth0DeviceCodeCredentials#prompt_user") { "Unable to launch url in browser" }
+        end
 
         puts <<~EOF
           Visit \e[92m#{polling_info[:verification_uri_complete]}\e[0m to complete authentication by following the below steps:

--- a/lib/cipherstash/client/auth0_device_code_credentials.rb
+++ b/lib/cipherstash/client/auth0_device_code_credentials.rb
@@ -152,7 +152,7 @@ module CipherStash
           Launchy.open polling_info[:verification_uri_complete]
         rescue Launchy::Error
           # We could be running in a headless environment, in which case, the user should just open the url in a browser on a separate machine
-          @logger.debug("Auth0DeviceCodeCredentials#prompt_user") { "Unable to launch url in browser" }
+          @logger.debug("Auth0DeviceCodeCredentials#prompt_user") { "Unable to launch URL in browser" }
         end
 
         puts <<~EOF

--- a/lib/cipherstash/client/auth0_device_code_credentials.rb
+++ b/lib/cipherstash/client/auth0_device_code_credentials.rb
@@ -150,7 +150,7 @@ module CipherStash
 
         begin
           Launchy.open polling_info[:verification_uri_complete]
-        rescue Launchy::CommandNotFoundError
+        rescue Launchy::Error
           # We could be running in a headless environment, in which case, the user should just open the url in a browser on a separate machine
           @logger.debug("Auth0DeviceCodeCredentials#prompt_user") { "Unable to launch url in browser" }
         end

--- a/lib/cipherstash/client/auth0_device_code_credentials.rb
+++ b/lib/cipherstash/client/auth0_device_code_credentials.rb
@@ -156,6 +156,9 @@ module CipherStash
         end
 
         puts <<~EOF
+        
+          ### ACTION REQUIRED ###
+                  
           Visit \e[92m#{polling_info[:verification_uri_complete]}\e[0m to complete authentication by following the below steps:
 
           1. Verify that this code matches the code in your browser


### PR DESCRIPTION
Super simple PR to just silence the `Launchy::Error` exception, especially for running in `headless` environment.
I believe this is sufficient as the existing shell instructions are sufficient to guide the user through.

Current behaviour before this fix:
```
ubuntu@ubuntu-test-rails:~/blog$ rake active_stash:login[ABCDEQWERTY1234]
D, [2022-08-25T04:42:28.229643 #10074] DEBUG -- CipherStash::Client::Profile.create: Created ~/.cipherstash
D, [2022-08-25T04:42:28.229712 #10074] DEBUG -- CipherStash::Client::Profile.create: Created ~/.cipherstash/default
D, [2022-08-25T04:42:28.230977 #10074] DEBUG -- CipherStash::Client::Profile.create: Wrote ~/.cipherstash/default/profile-config.json
D, [2022-08-25T04:42:28.231003 #10074] DEBUG -- CipherStash::Profile.load: Reading data for profile 'default' from ~/.cipherstash/default/profile-config.json
D, [2022-08-25T04:42:28.231076 #10074] DEBUG -- CipherStash::Profile.override_profile: Setting service.workspace to "ABCDEQWERTY1234" from workspace
D, [2022-08-25T04:42:28.231110 #10074] DEBUG -- CipherStash::Client::Profile.new: Creating profile named "default" from {"service"=>{"host"=>"ap-southeast-2.aws.stashdata.net", "port"=>443, "workspace"=>"ABCDEQWERTY1234"}, "identityProvider"=>{"kind"=>"Auth0-DeviceCode", "host"=>"auth.cipherstash.com", "clientId"=>"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}
D, [2022-08-25T04:42:28.231128 #10074] DEBUG -- CipherStash::Client::Profile#refresh_from_console: Fetching KMS/naming key details for workspace ABCDEQWERTY1234
D, [2022-08-25T04:42:28.231152 #10074] DEBUG -- CipherStash::Profile: Using device code authentication
D, [2022-08-25T04:42:28.231217 #10074] DEBUG -- Auth0DeviceCodeCredentials#expired?: No expiry on cached token
D, [2022-08-25T04:42:28.231231 #10074] DEBUG -- Auth0DeviceCodeCredentials#fresh_credentials: cached credentials are stale
D, [2022-08-25T04:42:28.231266 #10074] DEBUG -- Auth0DeviceCodeCredentials: POST /oauth/device/code {:audience=>"ap-southeast-2.aws.stashdata.net", :client_id=>"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", :scope=>"collection.create collection.delete collection.info collection.list document.put document.delete document.get document.query offline_access ws:ABCDEQWERTY1234"}
rake aborted!
Launchy::CommandNotFoundError: Unable to find a browser command. If this is unexpected, Please rerun with environment variable LAUNCHY_DEBUG=true or the '-d' commandline option and file a bug at https://github.com/copiousfreetime/launchy/issues/new
/var/lib/gems/3.0.0/gems/launchy-2.5.0/lib/launchy/applications/browser.rb:63:in `browser_cmdline'
/var/lib/gems/3.0.0/gems/launchy-2.5.0/lib/launchy/applications/browser.rb:67:in `cmd_and_args'
/var/lib/gems/3.0.0/gems/launchy-2.5.0/lib/launchy/applications/browser.rb:78:in `open'
/var/lib/gems/3.0.0/gems/launchy-2.5.0/lib/launchy.rb:30:in `open'
/var/lib/gems/3.0.0/gems/cipherstash-client-0.15.1/lib/cipherstash/client/auth0_device_code_credentials.rb:151:in `prompt_user'
/var/lib/gems/3.0.0/gems/cipherstash-client-0.15.1/lib/cipherstash/client/auth0_device_code_credentials.rb:47:in `acquire_new_token'
/var/lib/gems/3.0.0/gems/cipherstash-client-0.15.1/lib/cipherstash/client/auth0_device_code_credentials.rb:20:in `fresh_credentials'
/var/lib/gems/3.0.0/gems/cipherstash-client-0.15.1/lib/cipherstash/client/profile.rb:379:in `with_access_token'
/var/lib/gems/3.0.0/gems/cipherstash-client-0.15.1/lib/cipherstash/client/profile.rb:465:in `refresh_from_console'
/var/lib/gems/3.0.0/gems/cipherstash-client-0.15.1/lib/cipherstash/client/profile.rb:105:in `create'
/var/lib/gems/3.0.0/gems/active_stash-0.7.0/lib/tasks/active_stash.rake:59:in `block (2 levels) in <main>'
/usr/share/rubygems-integration/all/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
Tasks: TOP => active_stash:login
(See full trace by running task with --trace)
```

error: `Launchy::CommandNotFoundError: Unable to find a browser command. If this is unexpected, Please rerun with environment variable LAUNCHY_DEBUG=true or the '-d' commandline option and file a bug at https://github.com/copiousfreetime/launchy/issues/new`