### PR TITLE
Add logic to update workspace used for default profile

### DIFF
--- a/lib/cipherstash/client/profile.rb
+++ b/lib/cipherstash/client/profile.rb
@@ -394,11 +394,7 @@ module CipherStash
       # @see #with_kms_credentials because it has a more in-depth explanation of what's going on and why.
       #
       def with_access_token(&blk)
-        puts "block======="
-        p blk
         @access_token_creds_provider ||= access_token_provider(**symbolize_keys(identity_provider_config))
-        p identity_provider_config
-        p @access_token_creds_provider
 
         if blk.nil?
           @access_token_creds_provider.fresh_credentials
@@ -542,7 +538,6 @@ module CipherStash
           when "Auth0-AccessToken"
             access_token_static_credentials(**opts)
           when "Auth0-DeviceCode"
-            puts "hitting auth0 device code-----------"
             access_token_device_code_credentials(**opts)
           when "Console-AccessKey"
             access_token_console_access_key_credentials(**opts)
@@ -563,12 +558,7 @@ module CipherStash
       #
       # If the token can't be read for any reason, just return a null token, because you're supposed to refresh the token if it's out-of-date anyway.
       def cached_token
-        puts "self -----------"
-        p self
-        test = JSON.parse(File.read(file_path("auth-token.json")))
-        puts "auth token json #########"
-        p test
-        test
+        JSON.parse(File.read(file_path("auth-token.json")))
       rescue
         { "accessToken": "", "refreshToken": "", expiry: 0 }
       end


### PR DESCRIPTION
When `rake active_stash:login\[someworkspaceID\]` is run in ActiveStash, the default profile name that is sent through is `"default"`.

If a default profile folder already exists, then StashRB returns an error `Could not create profile default: already exists`. Even if a different workspace ID is passed through, the same error will be returned. So there isn't a way to update the default profile to use a different workspace.

This PR adds logic in the rescue to check if the profile name is `"default"`, then will check to see if the incoming workspace ID matches the existing workspace ID in the default profile. 

If they match, the existing error is returned, `Could not create profile default: already exists`.

If the workspace ID's don't match, then the existing auth-token.json file is deleted, and the existing profile-config.json file is overwritten with default settings.

When the profile is loaded, a new auth token, and auth-token.json file is created for the incoming workspace ID and the profile-config file is updated with the incoming workspace ID and naming key, key arn details in the default folder.
