### PR TITLE
Add `CipherStash::Client.login` class method

### DIFF
--- a/lib/cipherstash/client.rb
+++ b/lib/cipherstash/client.rb
@@ -46,8 +46,8 @@ module CipherStash
     #
     # @raise [CipherStash::Client::Error::LoadProfileFailure] if a workspace is not given and an existing profile could not be loaded.
     #
-    def self.log_in(workspace: nil, profile_name: nil, logger: default_logger)
-      Profile.log_in(workspace: workspace, profile_name: profile_name, logger: logger)
+    def self.login(workspace: nil, profile_name: nil, logger: default_logger)
+      Profile.login(workspace: workspace, profile_name: profile_name, logger: logger)
       true
     end
 

--- a/lib/cipherstash/client.rb
+++ b/lib/cipherstash/client.rb
@@ -31,6 +31,26 @@ module CipherStash
       Profile.profile_options
     end
 
+
+    # Log into a CipherStash workspace.
+    #
+    # If `workspace` is given, a profile will be created for that workspace.
+    # This is useful for logging into a workspace for the first time.
+    #
+    # If a workspace is not provided, this command will load an existing profile and then log in using that profile.
+    # The profile name defaults to "default", but can be overridden with the `CS_PROFILE_NAME` env var or the `defaultProfile` opt in `{cs_config_path}/config.json`.
+    #
+    # @return [TrueClass]
+    #
+    # @raise [CipherStash::Client::Error::CreateProfileFailure] if a workspace is given and a new profile could not be created.
+    #
+    # @raise [CipherStash::Client::Error::LoadProfileFailure] if a workspace is not given and an existing profile could not be loaded.
+    #
+    def self.log_in(workspace: nil, profile_name: nil, logger: default_logger)
+      Profile.log_in(workspace: workspace, profile_name: profile_name, logger: logger)
+      true
+    end
+
     # Create a new CipherStash client.
     #
     # No options are necessary in the common case.
@@ -79,7 +99,7 @@ module CipherStash
     #
     def initialize(profileName: Unspecified, logger: Unspecified, metrics: Metrics::Null.new, rpc_class: RPC, **opts)
       @logger = if logger == Unspecified
-                  Logger.new($stderr).tap { |l| l.level = Logger::WARN; l.formatter = ->(_, _, _, m) { "#{m}\n" } }
+                  self.class.default_logger
                 else
                   logger
                 end
@@ -248,6 +268,13 @@ module CipherStash
     end
 
     private
+
+    def self.default_logger
+      Logger.new($stderr).tap do |l|
+        l.level = Logger::WARN
+        l.formatter = ->(_, _, _, m) { "#{m}\n" }
+      end
+    end
 
     def console
       @profile.with_access_token do |token|

--- a/lib/cipherstash/client/profile.rb
+++ b/lib/cipherstash/client/profile.rb
@@ -126,14 +126,14 @@ module CipherStash
         profile.save
       end
 
-      def self.log_in(workspace:, profile_name:, logger:)
-        is_initial_log_in = !workspace.nil?
+      def self.login(workspace:, profile_name:, logger:)
+        is_initial_login = !workspace.nil?
         profile_name = resolve_profile_name(profile_name)
 
-        if is_initial_log_in
+        if is_initial_login
           create(profile_name, logger, workspace: workspace)
         else
-          load(profile_name, logger).log_in
+          load(profile_name, logger).login
         end
       end
 
@@ -540,7 +540,7 @@ module CipherStash
         end
       end
 
-      def log_in
+      def login
         access_token_creds_provider = access_token_provider(**symbolize_keys(identity_provider_config))
         access_token_creds_provider.fresh_credentials
 


### PR DESCRIPTION
This PR adds a `CipherStash::Client.login` method for ActiveStash to use to perform logins.

See the docs in the diff for details.

Related ActiveStash PR: https://github.com/cipherstash/activestash/pull/87.