### PR TITLE
Fix bugs in `CipherStash::Client.login`

### DIFF
--- a/lib/cipherstash/client/profile.rb
+++ b/lib/cipherstash/client/profile.rb
@@ -128,7 +128,7 @@ module CipherStash
 
       def self.login(workspace:, profile_name:, logger:)
         is_initial_login = !workspace.nil?
-        profile_name = resolve_profile_name(profile_name)
+        profile_name = resolve_profile_name(profile_name) || "default"
 
         if is_initial_login
           create(profile_name, logger, workspace: workspace)


### PR DESCRIPTION
This PR fixes a couple of bugs in `CipherStash::Client.login` by always falling back to `"default"` as a profile name when creating or loading profiles.

In the PR for adding the `login` method (https://github.com/cipherstash/ruby-client/pull/23), I missed that `resolve_profile` does not fall back on `"default"` as a profile name. I didn't catch this while manually testing because a profile name was getting picked up from the `defaultProfile` property in my local `~/.cipherstash/config.json`. It wasn't until I tested by nuking my local `~/.cipherstash` dir (based on [a comment](https://github.com/cipherstash/activestash/pull/87#discussion_r981952340) from @fimac in a separate PR) that I realised that the default was not getting applied if a `~/.cipherstash` dir didn't already exist.

Always falling back on `"default"` as a profile name in the `login` method fixes a couple of bugs:
1. An error would be raised and a default profile would not be created if a workspace was given but a profile was not passed to `Client.login` (for example, when running `rake active_stash:login[SomeWorkspace]` for the first time).
2. If neither a workspace or profile name were given and a profile could not be loaded (for example, by accidentally running `rake active_stash:login` without args before a profile has been created), an unhelpful auth error would be raised. Always providing a profile name to `Profile#load` means that we will explicitly raise that a profile could not be loaded instead. This means that ActiveStash can handle this scenario properly a provide a more helpful error.