### PR TITLE
Update put stream to handle bi directional stream

### DIFF
--- a/cipherstash-client.gemspec
+++ b/cipherstash-client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "aws-sdk-core", "~> 3.0"
   s.add_runtime_dependency "aws-sdk-kms", "~> 1.0"
   s.add_runtime_dependency 'cbor', '~> 0.5.9.6'
-  s.add_runtime_dependency "cipherstash-grpc", "= 0.20220801.1"
+  s.add_runtime_dependency "cipherstash-grpc", "= 0.20220928.0"
   s.add_runtime_dependency "enveloperb", "~> 0.0"
   s.add_runtime_dependency "launchy", "~> 2.5"
   s.add_runtime_dependency "ore-rs", "~> 0.0"

--- a/lib/cipherstash/client/rpc.rb
+++ b/lib/cipherstash/client/rpc.rb
@@ -278,7 +278,7 @@ module CipherStash
             unless res.is_a?(Documents::StreamingPutReply)
               raise Error::StreamingPutFailure, "expected Documents::StreamingPutReply response, got #{res.class} instead"
             end
-            @logger.info("Cipherstash::Client::RPC#put_stream") { "#{res.numInserted} records inserted." }
+            @logger.debug("Cipherstash::Client::RPC#put_stream") { "#{res.numInserted} records inserted." }
 
             num_inserted = res.numInserted
           end

--- a/lib/cipherstash/client/rpc.rb
+++ b/lib/cipherstash/client/rpc.rb
@@ -278,6 +278,9 @@ module CipherStash
             unless res.is_a?(Documents::StreamingPutReply)
               raise Error::StreamingPutFailure, "expected Documents::StreamingPutReply response, got #{res.class} instead"
             end
+
+            raise_if_error(res)
+
             @logger.debug("Cipherstash::Client::RPC#put_stream") { "#{res.numInserted} records inserted." }
 
             num_inserted = res.numInserted

--- a/lib/cipherstash/client/rpc.rb
+++ b/lib/cipherstash/client/rpc.rb
@@ -284,7 +284,7 @@ module CipherStash
           end
         end
 
-        @logger.info("Cipherstash::Client::RPC#put_stream") { "Streaming upsert complete. Number of records inserted: #{res.numInserted}" }
+        @logger.debug("Cipherstash::Client::RPC#put_stream") { "Streaming upsert complete. Number of records inserted: #{res.numInserted}" }
 
         num_inserted
       rescue ::GRPC::NotFound

--- a/lib/cipherstash/client/rpc.rb
+++ b/lib/cipherstash/client/rpc.rb
@@ -271,7 +271,7 @@ module CipherStash
         requests = [[begin_request], records].lazy.flat_map { |x| x }
 
         num_inserted = 0
-        @logger.info("Cipherstash::Client::RPC#put_stream") { "Start streaming upsert of documents..." }
+        @logger.debug("Cipherstash::Client::RPC#put_stream") { "Start streaming upsert of documents..." }
 
         @metrics.measure_rpc_call("putStream") do
           stub.put_stream_bi_direction(requests, metadata: rpc_headers).each do |res|


### PR DESCRIPTION
Bumps the grpc client to use the latest version.

Updates the put_stream method to use the bi_directional endpoint. This returns an enumerable when called, which is then looped through to log each response, which has the current count of the total number inserted.

Testing done:

Have tested using this [branch of the benchmark repo](https://github.com/cipherstash/activestash-reindex-benchmark/compare/gather-benchmarking?expand=1). Pointing the gemfile to a local version of active stash and this branch of the ruby client.

Results below are via running this on an EC2 instance.

<img width="715" alt="Screen Shot 2022-10-10 at 3 19 59 pm" src="https://user-images.githubusercontent.com/26052576/194971160-11196d2b-5771-406a-8716-2096f5d3b2bf.png">
<img width="714" alt="Screen Shot 2022-10-10 at 10 01 48 pm" src="https://user-images.githubusercontent.com/26052576/194971169-72933161-d055-4ff6-bea2-4547ac52ce26.png">


I have also tested [via this branch which has been updated with an E2E test ](https://github.com/cipherstash/platform/pull/1203)for streaming upsert and error handling on a unique constraint.

Running the below command, with this ruby client branch checked out.

` CS_SERVICE_PORT=50001 RUBYLIB=/users/fionamccawley/cipherstash/ruby-client/lib ./run.sh dev-local 0`

<img width="1401" alt="Screen Shot 2022-10-11 at 11 19 34 am" src="https://user-images.githubusercontent.com/26052576/194971311-2eba7513-41ff-4ddb-8814-8f3c12cf0474.png">

The active stash smoke test is failing due to an mismatch in ruby client versions. Looks like we need to do a release of ActiveStash so the latest update including the bump in versions is avaialble.
