### PR TITLE
Fix ngram tokenization

### DIFF
--- a/lib/cipherstash/analysis/text_processor.rb
+++ b/lib/cipherstash/analysis/text_processor.rb
@@ -16,7 +16,7 @@ module CipherStash
       # Processor.new({
       #   "tokenFilters"=>[
       #     {"kind"=>"downcase"},
-      #     {"kind"=>"ngram", "minLength"=>3, "maxLength"}
+      #     {"kind"=>"ngram", "minLength"=>3, "maxLength"=>8}
       #   ],
       #   "tokenizer"=>{"kind"=>"standard"}
       # })

--- a/lib/cipherstash/analysis/text_processor.rb
+++ b/lib/cipherstash/analysis/text_processor.rb
@@ -46,18 +46,6 @@ module CipherStash
             TokenFilters::Downcase.new(obj)
 
           when "ngram"
-            if obj["tokenLength"]
-              raise CipherStash::Client::Error::InternalError, "'tokenLength' is deprecated. Use 'minLength' and 'maxLength' for the ngram filter."
-            end
-
-            unless obj["minLength"].instance_of?(Integer) && obj["maxLength"].instance_of?(Integer)
-              raise CipherStash::Client::Error::InternalError, "The values provided to the min and max length must be of type Integer."
-            end
-
-            unless obj["maxLength"] >= obj["minLength"]
-                raise CipherStash::Client::Error::InternalError, "The ngram filter min length must be less than or equal to the max length"
-            end
-
             TokenFilters::NGram.new(obj)
 
           else

--- a/lib/cipherstash/analysis/text_processor.rb
+++ b/lib/cipherstash/analysis/text_processor.rb
@@ -16,7 +16,7 @@ module CipherStash
       # Processor.new({
       #   "tokenFilters"=>[
       #     {"kind"=>"downcase"},
-      #     {"kind"=>"ngram", "tokenLength"=>3}
+      #     {"kind"=>"ngram", "minLength"=>3, "maxLength"}
       #   ],
       #   "tokenizer"=>{"kind"=>"standard"}
       # })
@@ -46,6 +46,14 @@ module CipherStash
             TokenFilters::Downcase.new(obj)
 
           when "ngram"
+            unless obj["minLength"].instance_of?(Integer) && obj["maxLength"].instance_of?(Integer)
+              raise CipherStash::Client::Error::InternalError, "The values provided to the min and max length must be of type Integer."
+            end
+
+            unless obj["maxLength"] >= obj["minLength"]
+                raise CipherStash::Client::Error::InternalError, "The ngram filter min length must be less than or equal to the max length"
+            end
+
             TokenFilters::NGram.new(obj)
 
           else

--- a/lib/cipherstash/analysis/text_processor.rb
+++ b/lib/cipherstash/analysis/text_processor.rb
@@ -46,6 +46,10 @@ module CipherStash
             TokenFilters::Downcase.new(obj)
 
           when "ngram"
+            if obj["tokenLength"]
+              raise CipherStash::Client::Error::InternalError, "'tokenLength' is deprecated. Use 'minLength' and 'maxLength' for the ngram filter."
+            end
+
             unless obj["minLength"].instance_of?(Integer) && obj["maxLength"].instance_of?(Integer)
               raise CipherStash::Client::Error::InternalError, "The values provided to the min and max length must be of type Integer."
             end

--- a/lib/cipherstash/analysis/token_filters.rb
+++ b/lib/cipherstash/analysis/token_filters.rb
@@ -15,13 +15,24 @@ module CipherStash
 
       class NGram < Base
         def perform(str_or_array)
-          token_length = @opts["tokenLength"] || 3
+          min_length = @opts["minLength"] || 3
+          max_length = @opts["maxLength"] || 8
+
           Array(str_or_array).flat_map do |token|
-            [].tap do |out|
-              (token.length - token_length + 1).times do |i|
-                out << token[i, token_length]
+            token_length = token.length
+
+            ngrams = [].tap do |out|
+              (min_length..max_length).each do |n|
+                ngram = token.chars.each_cons(n).map(&:join)
+                out << ngram
+              end
+
+              if token_length > max_length
+                out << token
               end
             end
+
+            ngrams.flatten
           end
         end
       end

--- a/spec/cipherstash/analysis/text_processor_spec.rb
+++ b/spec/cipherstash/analysis/text_processor_spec.rb
@@ -1,0 +1,87 @@
+require 'cipherstash/analysis/text_processor'
+require "cipherstash/client"
+
+RSpec.describe CipherStash::Analysis::TextProcessor do
+  describe "Standard text processor" do
+    it "splits text based on word boundaries" do
+      tokenizer =
+        CipherStash::Analysis::TextProcessor.new({
+          "tokenFilters" => [
+            { "kind" => "downcase" }
+          ],
+         "tokenizer" => { "kind" => "standard" }
+        })
+      result = tokenizer.perform("This is an example of a standard tokenizer")
+      expect(result.length).to eq(8)
+      expect(result).to eq(["this", "is", "an", "example", "of", "a", "standard", "tokenizer"])
+    end
+  end
+
+  describe "Standard text processor with an ngram filter" do
+    ["1", { foo: "bar" }, Object.new].each do |length|
+      it "raises an error if invalid length of #{length.inspect} provided" do
+        expect {
+          CipherStash::Analysis::TextProcessor.new({
+            "tokenFilters" => [
+              { "kind" => "downcase" },
+              { "kind" => "ngram", "minLength" => length, "maxLength" => length }
+              ],
+            "tokenizer" => { "kind" => "standard" }
+          })
+        }.to raise_error(CipherStash::Client::Error::InternalError, "The values provided to the min and max length must be of type Integer.")
+      end
+    end
+
+    it "raises an error if the min length is greater than the max length" do
+      expect {
+        CipherStash::Analysis::TextProcessor.new({
+          "tokenFilters" => [
+            { "kind" => "downcase" },
+            { "kind" => "ngram", "minLength" => 4, "maxLength" => 3 }
+          ],
+          "tokenizer" => { "kind" => "standard" }
+        })
+        }.to raise_error(CipherStash::Client::Error::InternalError, "The ngram filter min length must be less than or equal to the max length")
+    end
+
+    it "splits text into ngrams using min length of 3 and max length of 8" do
+      tokenizer =
+        CipherStash::Analysis::TextProcessor.new({
+          "tokenFilters" => [
+            { "kind" => "downcase" },
+            { "kind" => "ngram", "minLength" => 3, "maxLength" => 8 }
+          ],
+         "tokenizer" => { "kind" => "standard" }
+        })
+      result = tokenizer.perform("Example filter")
+
+      expect(result).to eq([
+        "exa",
+        "xam",
+        "amp",
+        "mpl",
+        "ple",
+        "exam",
+        "xamp",
+        "ampl",
+        "mple",
+        "examp",
+        "xampl",
+        "ample",
+        "exampl",
+        "xample",
+        "example",
+        "fil",
+        "ilt",
+        "lte",
+        "ter",
+        "filt",
+        "ilte",
+        "lter",
+        "filte",
+        "ilter",
+        "filter"
+      ])
+    end
+  end
+end

--- a/spec/cipherstash/analysis/text_processor_spec.rb
+++ b/spec/cipherstash/analysis/text_processor_spec.rb
@@ -18,44 +18,6 @@ RSpec.describe CipherStash::Analysis::TextProcessor do
   end
 
   describe "Standard text processor with an ngram filter" do
-    ["1", { foo: "bar" }, Object.new].each do |length|
-      it "raises an error if invalid length of #{length.inspect} provided" do
-        expect {
-          CipherStash::Analysis::TextProcessor.new({
-            "tokenFilters" => [
-              { "kind" => "downcase" },
-              { "kind" => "ngram", "minLength" => length, "maxLength" => length }
-              ],
-            "tokenizer" => { "kind" => "standard" }
-          })
-        }.to raise_error(CipherStash::Client::Error::InternalError, "The values provided to the min and max length must be of type Integer.")
-      end
-    end
-
-    it "raises an error if the min length is greater than the max length" do
-      expect {
-        CipherStash::Analysis::TextProcessor.new({
-          "tokenFilters" => [
-            { "kind" => "downcase" },
-            { "kind" => "ngram", "minLength" => 4, "maxLength" => 3 }
-          ],
-          "tokenizer" => { "kind" => "standard" }
-        })
-        }.to raise_error(CipherStash::Client::Error::InternalError, "The ngram filter min length must be less than or equal to the max length")
-    end
-
-    it "raises an error if tokenLength is provided" do
-      expect {
-        CipherStash::Analysis::TextProcessor.new({
-          "tokenFilters" => [
-            { "kind" => "downcase" },
-            { "kind" => "ngram", "tokenLength" => 3 }
-          ],
-          "tokenizer" => { "kind" => "standard" }
-        })
-      }.to raise_error(CipherStash::Client::Error::InternalError, "'tokenLength' is deprecated. Use 'minLength' and 'maxLength' for the ngram filter.")
-    end
-
     it "splits text into ngrams using min length of 3 and max length of 8" do
       tokenizer =
         CipherStash::Analysis::TextProcessor.new({

--- a/spec/cipherstash/analysis/text_processor_spec.rb
+++ b/spec/cipherstash/analysis/text_processor_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe CipherStash::Analysis::TextProcessor do
         }.to raise_error(CipherStash::Client::Error::InternalError, "The ngram filter min length must be less than or equal to the max length")
     end
 
+    it "raises an error if tokenLength is provided" do
+      expect {
+        CipherStash::Analysis::TextProcessor.new({
+          "tokenFilters" => [
+            { "kind" => "downcase" },
+            { "kind" => "ngram", "tokenLength" => 3 }
+          ],
+          "tokenizer" => { "kind" => "standard" }
+        })
+      }.to raise_error(CipherStash::Client::Error::InternalError, "'tokenLength' is deprecated. Use 'minLength' and 'maxLength' for the ngram filter.")
+    end
+
     it "splits text into ngrams using min length of 3 and max length of 8" do
       tokenizer =
         CipherStash::Analysis::TextProcessor.new({

--- a/spec/cipherstash/client_spec.rb
+++ b/spec/cipherstash/client_spec.rb
@@ -126,7 +126,7 @@ describe CipherStash::Client do
         def schema(kind)
           mapping = {
             "kind" => kind,
-            "tokenFilters" => [{"kind" => "downcase"}, {"kind" => "ngram", "tokenLength" => 3}],
+            "tokenFilters" => [{"kind" => "downcase"}, {"kind" => "ngram", "minLength" => 3, "maxLength" => 8}],
             "tokenizer" => {"kind" => "standard"}
           }
 
@@ -233,4 +233,4 @@ describe CipherStash::Client do
       end
     end
   end
-end 
+end

--- a/spec/cipherstash/index_spec.rb
+++ b/spec/cipherstash/index_spec.rb
@@ -16,7 +16,7 @@ describe CipherStash::Index do
       "mapping" => {
         "kind" => kind,
         "fields" => ["title"],
-        "tokenFilters" => [{"kind"=>"downcase"}, {"kind"=>"ngram", "tokenLength"=>3}],
+        "tokenFilters" => [{"kind"=>"downcase"}, {"kind"=>"ngram", "minLength" => 3, "maxLength" => 8}],
         "tokenizer" => {"kind"=>"standard"},
         "fieldType" => "string",
       }
@@ -33,7 +33,7 @@ describe CipherStash::Index do
       },
       "mapping" => {
         "kind" => kind,
-        "tokenFilters" => [{"kind"=>"downcase"}, {"kind"=>"ngram", "tokenLength"=>3}],
+        "tokenFilters" => [{"kind"=>"downcase"}, {"kind"=>"ngram", "minLength" => 3, "maxLength" => 8}],
         "tokenizer" => {"kind"=>"standard"},
         "fieldType" => "string",
       }


### PR DESCRIPTION
https://www.notion.so/cipherstash/Bug-Text-query-false-positives-4ded8023f76e4bac869bca71cbad3c14

This PR updates the ngram filter to generate ngrams using a min and max length.

If the token length is greater than the max length, the whole token is also added to the ngrams.