### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/release_gems.yml
+++ b/.github/workflows/release_gems.yml
@@ -22,6 +22,6 @@ jobs:
 
       - name: Build+push
         run: |
-          rake gem gem:push
+          bundle exec rake gem gem:push
         env:
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
```
rake aborted!
Gem::LoadError: You have already activated rake 13.0.1, but your Gemfile requires rake 13.0.6. Prepending `bundle exec` to your command may solve this.
```

I don't know if this fix will work but will try doing what the error suggests.